### PR TITLE
fix: add workflow to proxy allowedParams

### DIFF
--- a/main.go
+++ b/main.go
@@ -569,7 +569,7 @@ func handleGitHubProxy(w http.ResponseWriter, r *http.Request) {
 	allowedParams := map[string]bool{
 		"state": true, "per_page": true, "page": true, "sort": true,
 		"direction": true, "since": true, "until": true, "status": true,
-		"sha": true, "ref": true, "path": true,
+		"sha": true, "ref": true, "path": true, "workflow": true,
 	}
 	filtered := make([]string, 0, len(r.URL.Query()))
 	for k, vs := range r.URL.Query() {


### PR DESCRIPTION
## Summary

- Adds `workflow` to the GitHub API proxy query parameter allowlist
- Without this, `/actions/runs?workflow=goose-build.yml` silently drops the filter, returning all 11,273 runs instead of Goose-only runs
- This caused the dashboard to show incorrect Goose success rate

## Test plan

- [ ] `curl chimney.beerpub.dev/api/github/actions/runs?workflow=goose-build.yml&per_page=1` returns only Goose runs
- [ ] Dashboard Goose pass rate reflects actual Goose build outcomes